### PR TITLE
Add ablation_examples() and refactor ExemplarValidator for DRY

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -42,11 +42,6 @@ llm = ChatOpenAI(
 
 validator = ExemplarValidator(prompt, llm)
 
-ablation_result = validator.ablation_test()
-print("Ablation test results:")
-print(ablation_result)
-print("\n")
-
 replay_result = validator.replay_test()
 print("Replay test results (original examples):")
 print(replay_result)
@@ -58,5 +53,20 @@ updated_prompt.examples = validator.replay_examples()
 updated_validator = ExemplarValidator(updated_prompt, llm)
 
 updated_replay_result = updated_validator.replay_test()
-print("Replay test results (updated examples):")
+print("Replay test results (replayed examples):")
 print(updated_replay_result)
+print("\n")
+
+ablation_result = validator.ablation_test()
+print("Ablation test results (original examples):")
+print(ablation_result)
+print("\n")
+
+# Generate examples using ablation methodology
+ablated_prompt = prompt.model_copy()
+ablated_prompt.examples = validator.ablation_examples()
+ablated_validator = ExemplarValidator(ablated_prompt, llm)
+
+updated_ablation_result = ablated_validator.ablation_test()
+print("Ablation test results (ablated examples):")
+print(updated_ablation_result)

--- a/demo.py
+++ b/demo.py
@@ -42,27 +42,12 @@ llm = ChatOpenAI(
 
 validator = ExemplarValidator(prompt, llm)
 
-replay_result = validator.replay_test()
-print("Replay test results (original examples):")
-print(replay_result)
-print("\n")
-
-# Update examples with replay results
-updated_prompt = prompt.model_copy()
-updated_prompt.examples = validator.replay_examples()
-updated_validator = ExemplarValidator(updated_prompt, llm)
-
-updated_replay_result = updated_validator.replay_test()
-print("Replay test results (replayed examples):")
-print(updated_replay_result)
-print("\n")
-
+# Ablation method
 ablation_result = validator.ablation_test()
 print("Ablation test results (original examples):")
 print(ablation_result)
 print("\n")
 
-# Generate examples using ablation methodology
 ablated_prompt = prompt.model_copy()
 ablated_prompt.examples = validator.ablation_examples()
 ablated_validator = ExemplarValidator(ablated_prompt, llm)
@@ -70,3 +55,18 @@ ablated_validator = ExemplarValidator(ablated_prompt, llm)
 updated_ablation_result = ablated_validator.ablation_test()
 print("Ablation test results (ablated examples):")
 print(updated_ablation_result)
+print("\n")
+
+# Replay method
+replay_result = validator.replay_test()
+print("Replay test results (original examples):")
+print(replay_result)
+print("\n")
+
+replayed_prompt = prompt.model_copy()
+replayed_prompt.examples = validator.replay_examples()
+replayed_validator = ExemplarValidator(replayed_prompt, llm)
+
+updated_replay_result = replayed_validator.replay_test()
+print("Replay test results (replayed examples):")
+print(updated_replay_result)


### PR DESCRIPTION
- Add new ablation_examples() method that returns examples with answers generated using ablation methodology
- Extract common validation logic into _validate_examples() helper
- Extract ablated prompt creation into _create_ablated_prompt() helper
- Eliminate duplicate code across ablation_test() and ablation_examples()
- Fix type safety by defaulting to empty list instead of None
- Add comprehensive test for ablation_examples() functionality
- Update demo to show ablation workflow: original -> replay -> ablation -> ablated examples

🤖 Generated with [Claude Code](https://claude.ai/code)